### PR TITLE
Use DeviceStateManager on Android 12 to detect the fold state

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
     implementation 'androidx.activity:activity-ktx:1.4.0'
     implementation "androidx.fragment:fragment-ktx:1.4.0"
+    implementation 'org.lsposed.hiddenapibypass:hiddenapibypass:4.2'
+
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/java/com/denytheflowerpot/scrunch/ScrunchApplication.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/ScrunchApplication.kt
@@ -8,6 +8,8 @@ import com.denytheflowerpot.scrunch.managers.NotificationManager
 import com.denytheflowerpot.scrunch.managers.SettingsManager
 import com.denytheflowerpot.scrunch.managers.SoundPlaybackManager
 import com.denytheflowerpot.scrunch.services.FoldActionSignalingService
+import com.denytheflowerpot.scrunch.util.PermissionUtils
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 
 class ScrunchApplication: Application() {
     val settingsManager: SettingsManager by lazy {
@@ -20,13 +22,16 @@ class ScrunchApplication: Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        HiddenApiBypass.addHiddenApiExemptions("")
+
         instance = this
         soundPlaybackManager.loadPreviousSounds()
         startServiceIfNeeded()
     }
 
     fun startServiceIfNeeded() {
-        if (settingsManager.serviceStarted && checkSelfPermission(Manifest.permission.READ_LOGS) == PackageManager.PERMISSION_GRANTED) {
+        if (settingsManager.serviceStarted && !PermissionUtils.needsToGrantReadLogs(this)) {
             startForegroundService(getServiceIntent(true))
         }
     }

--- a/app/src/main/java/com/denytheflowerpot/scrunch/helpers/folding/FoldDetectionStrategies.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/helpers/folding/FoldDetectionStrategies.kt
@@ -2,6 +2,7 @@ package com.denytheflowerpot.scrunch.helpers.folding
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Resources
 import android.hardware.devicestate.DeviceStateManager
 import android.os.Build
 import android.util.Log
@@ -48,13 +49,13 @@ class Android12DetectionStrategy : FoldDetectionStrategy {
     private var stateCallback: DeviceStateManager.DeviceStateCallback? = null
 
     override fun create(context: Context, callback: (Int) -> Unit) {
-        val array = context.resources.getStringArray(com.android.internal.R.array.config_device_state_postures)
+        val array = Resources.getSystem().getStringArray(com.android.internal.R.array.config_device_state_postures)
         val stateMapping = hashMapOf<Int, Int>()
 
         stateMapping.putAll(array.map { it.split(":").run { this[0].toInt() to this[1].toInt() } })
 
         stateCallback = DeviceStateManager.DeviceStateCallback { state ->
-            callback(stateMapping[state] ?: FoldActionSignalingService.DEVICE_STATE_FULLY_OPEN)
+            callback(stateMapping[state] ?: state)
         }
 
         dsm(context).registerCallback(context.mainExecutor, stateCallback)

--- a/app/src/main/java/com/denytheflowerpot/scrunch/helpers/folding/FoldDetectionStrategies.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/helpers/folding/FoldDetectionStrategies.kt
@@ -2,7 +2,6 @@ package com.denytheflowerpot.scrunch.helpers.folding
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.res.Resources
 import android.hardware.devicestate.DeviceStateManager
 import android.os.Build
 import android.util.Log
@@ -49,8 +48,14 @@ class Android12DetectionStrategy : FoldDetectionStrategy {
     private var stateCallback: DeviceStateManager.DeviceStateCallback? = null
 
     override fun create(context: Context, callback: (Int) -> Unit) {
-        val array = Resources.getSystem().getStringArray(com.android.internal.R.array.config_device_state_postures)
+        var array = context.resources.getStringArray(com.android.internal.R.array.config_device_state_postures)
         val stateMapping = hashMapOf<Int, Int>()
+
+        if (array.isNullOrEmpty()) {
+            array = context.resources.getStringArray(
+                context.resources.getIdentifier("config_device_state_postures", "array", "android")
+            )
+        }
 
         stateMapping.putAll(array.map { it.split(":").run { this[0].toInt() to this[1].toInt() } })
 

--- a/app/src/main/java/com/denytheflowerpot/scrunch/helpers/folding/FoldDetectionStrategies.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/helpers/folding/FoldDetectionStrategies.kt
@@ -1,37 +1,74 @@
 package com.denytheflowerpot.scrunch.helpers.folding
 
+import android.annotation.SuppressLint
+import android.content.Context
+import android.hardware.devicestate.DeviceStateManager
 import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import com.denytheflowerpot.scrunch.services.FoldActionSignalingService
+import kotlinx.coroutines.*
 
 interface FoldDetectionStrategy {
-    val logcatTraceTag: String //initial filtering
-    val logcatTracePrefix: String //extra filtering
-    //actual processing
-    //true = folded
-    //false = unfolded
-    //null = not a valid line
-    val processLogcatTrace: (line: String, previousState: Boolean?) -> (Boolean?)
+    fun create(context: Context, callback: (Int) -> Unit)
+    fun destroy(context: Context)
 
     companion object {
+        private var _instance: FoldDetectionStrategy? = null
+
         val instanceForThisDevice: FoldDetectionStrategy?
             get() {
-                return when (Build.DEVICE) {
-                    "q2q", //Z Fold3
-                    "f2q", //Z Fold2
-                    "winner", //Z Fold
-                    "winnerx", //Z Fold 5G
-                    "bloomq", //Z Flip
-                    "bloomxq", //Z Flip 5G
-                    "b2q" //Z Flip3
-                    -> GalaxyFoldDetectionStrategy(Build.VERSION.SDK_INT)
-                    "duo", //Duo 1
-                    -> SurfaceDuoDetectionStrategy()
-                    else -> null
+                return _instance ?: run {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        return Android12DetectionStrategy()
+                    }
+
+                    when (Build.DEVICE) {
+                        "q2q", //Z Fold3
+                        "f2q", //Z Fold2
+                        "winner", //Z Fold
+                        "winnerx", //Z Fold 5G
+                        "bloomq", //Z Flip
+                        "bloomxq", //Z Flip 5G
+                        "b2q" //Z Flip3
+                        -> GalaxyFoldDetectionStrategy(Build.VERSION.SDK_INT)
+                        "duo", //Duo 1
+                        -> SurfaceDuoDetectionStrategy()
+                        else -> null
+                    }
+                }.apply {
+                    _instance = this
                 }
             }
     }
 }
 
-class GalaxyFoldDetectionStrategy(val sdk: Int): FoldDetectionStrategy {
+@RequiresApi(Build.VERSION_CODES.S)
+class Android12DetectionStrategy : FoldDetectionStrategy {
+    private var stateCallback: DeviceStateManager.DeviceStateCallback? = null
+
+    override fun create(context: Context, callback: (Int) -> Unit) {
+        val array = context.resources.getStringArray(com.android.internal.R.array.config_device_state_postures)
+        val stateMapping = hashMapOf<Int, Int>()
+
+        stateMapping.putAll(array.map { it.split(":").run { this[0].toInt() to this[1].toInt() } })
+
+        stateCallback = DeviceStateManager.DeviceStateCallback { state ->
+            callback(stateMapping[state] ?: FoldActionSignalingService.DEVICE_STATE_FULLY_OPEN)
+        }
+
+        dsm(context).registerCallback(context.mainExecutor, stateCallback)
+    }
+
+    override fun destroy(context: Context) {
+        dsm(context).unregisterCallback(stateCallback)
+    }
+
+    @SuppressLint("WrongConstant")
+    private fun dsm(context: Context) = context.getSystemService(Context.DEVICE_STATE_SERVICE) as DeviceStateManager
+}
+
+class GalaxyFoldDetectionStrategy(val sdk: Int) : LogcatDetectionStrategy() {
     override val logcatTraceTag: String
         get() = if (sdk >= 31) "WindowManagerServiceExt" else "DisplayFoldController"
     override val logcatTracePrefix: String
@@ -46,7 +83,7 @@ class GalaxyFoldDetectionStrategy(val sdk: Int): FoldDetectionStrategy {
         }
 }
 
-class SurfaceDuoDetectionStrategy: FoldDetectionStrategy {
+class SurfaceDuoDetectionStrategy : LogcatDetectionStrategy() {
     override val logcatTraceTag: String
         get() = "PostureMonitor"
     override val logcatTracePrefix: String
@@ -64,4 +101,65 @@ class SurfaceDuoDetectionStrategy: FoldDetectionStrategy {
                 }
             } else null
         }
+}
+
+abstract class LogcatDetectionStrategy : FoldDetectionStrategy {
+    abstract val logcatTraceTag: String //initial filtering
+    abstract val logcatTracePrefix: String //extra filtering
+    //actual processing
+    //true = folded
+    //false = unfolded
+    //null = not a valid line
+    abstract val processLogcatTrace: (line: String, previousState: Boolean?) -> (Boolean?)
+
+    private var currentFoldState: Boolean? = null
+    private var runningJob: Job? = null
+    private var scope: CoroutineScope? = null
+
+    override fun create(context: Context, callback: (Int) -> Unit) {
+        scope = CoroutineScope(Job() + Dispatchers.IO)
+        runningJob = scope?.launch { execute(callback) }
+    }
+
+    override fun destroy(context: Context) {
+        scope?.cancel()
+        runningJob?.cancel("Normal stop")
+        runningJob = null
+    }
+
+    private suspend fun execute(callback: (Int) -> Unit) {
+        Runtime.getRuntime().exec("logcat -c")
+        Runtime.getRuntime()
+            .exec("logcat ${logcatTraceTag}:V *:S -e $logcatTracePrefix")
+            .inputStream
+            .bufferedReader()
+            .useLines { lines ->
+                try {
+                    lines.forEach { line ->
+                        if (!currentCoroutineContext().isActive) {
+                            throw FoldActionSignalingService.DummyStopServiceException()
+                        }
+
+                        val folded = processLogcatTrace(line, currentFoldState)
+                        if (folded != null) {
+                            Log.d("Scrunch", "Fold status is $folded")
+                            if (currentFoldState == null) {
+                                currentFoldState = folded
+                            } else {
+                                if (folded != currentFoldState) {
+                                    callback(if (folded) FoldActionSignalingService.DEVICE_STATE_CLOSED else FoldActionSignalingService.DEVICE_STATE_FULLY_OPEN)
+                                    currentFoldState = folded
+                                }
+                            }
+                        } else {
+                            Log.d("Scrunch", "Invalid line: $line")
+                        }
+                    }
+                } catch (e: Exception) {
+                    if (e !is FoldActionSignalingService.DummyStopServiceException) {
+                        Log.d("Scrunch", "Error: $e")
+                    }
+                }
+            }
+    }
 }

--- a/app/src/main/java/com/denytheflowerpot/scrunch/services/FoldActionSignalingService.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/services/FoldActionSignalingService.kt
@@ -1,14 +1,10 @@
 package com.denytheflowerpot.scrunch.services
 
 import android.app.Service
-import android.content.Context
 import android.content.Intent
-import android.hardware.devicestate.DeviceStateManager
 import android.os.IBinder
-import android.util.Log
 import com.denytheflowerpot.scrunch.ScrunchApplication
 import com.denytheflowerpot.scrunch.helpers.folding.FoldDetectionStrategy
-import kotlinx.coroutines.*
 
 class FoldActionSignalingService : Service() {
     //necessary in order to stop processing folding actions

--- a/app/src/main/java/com/denytheflowerpot/scrunch/services/FoldActionSignalingService.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/services/FoldActionSignalingService.kt
@@ -23,7 +23,7 @@ class FoldActionSignalingService : Service() {
             return START_NOT_STICKY
         }
 
-        return START_NOT_STICKY
+        return START_STICKY
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/denytheflowerpot/scrunch/services/FoldActionSignalingService.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/services/FoldActionSignalingService.kt
@@ -1,7 +1,9 @@
 package com.denytheflowerpot.scrunch.services
 
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.hardware.devicestate.DeviceStateManager
 import android.os.IBinder
 import android.util.Log
 import com.denytheflowerpot.scrunch.ScrunchApplication
@@ -9,55 +11,11 @@ import com.denytheflowerpot.scrunch.helpers.folding.FoldDetectionStrategy
 import kotlinx.coroutines.*
 
 class FoldActionSignalingService : Service() {
-
     //necessary in order to stop processing folding actions
     class DummyStopServiceException : Exception()
 
     private val notificationId = 4653
-
-    private var logcatJob: Job? = null
-    private var currentFoldState: Boolean? = null
-
-    private lateinit var foldDetectionStrategy: FoldDetectionStrategy
-    private lateinit var scope: CoroutineScope
-
-    private suspend fun announceFoldAction() = withContext(Dispatchers.IO) {
-        Runtime.getRuntime().exec("logcat -c")
-        Runtime.getRuntime()
-            .exec("logcat ${foldDetectionStrategy.logcatTraceTag}:V *:S -e ${foldDetectionStrategy.logcatTracePrefix}")
-            .inputStream
-            .bufferedReader()
-            .useLines { lines ->
-                try {
-                    lines.forEach { line ->
-                        if (!this.isActive) {
-                            throw DummyStopServiceException()
-                        }
-
-                        val folded = foldDetectionStrategy.processLogcatTrace(line, currentFoldState)
-                        if (folded != null) {
-                            Log.d("Scrunch", "Fold status is $folded")
-                            if (currentFoldState == null) {
-                                currentFoldState = folded
-                            } else {
-                                if (folded != currentFoldState) {
-                                    val soundPlaybackManager =
-                                        ScrunchApplication.instance.soundPlaybackManager
-                                    if (folded) soundPlaybackManager.playFoldSound() else soundPlaybackManager.playUnfoldSound()
-                                    currentFoldState = folded
-                                }
-                            }
-                        } else {
-                            Log.d("Scrunch", "Invalid line: $line")
-                        }
-                    }
-                } catch (e: Exception) {
-                    if (e !is DummyStopServiceException) {
-                        Log.d("Scrunch", "Error: $e")
-                    }
-                }
-            }
-    }
+    private var currentFoldState: Int? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent != null && intent.action == stopServiceAction) {
@@ -65,26 +23,29 @@ class FoldActionSignalingService : Service() {
             return START_NOT_STICKY
         }
 
-        if (logcatJob == null) {
-            val strategy = FoldDetectionStrategy.instanceForThisDevice
-            return if (strategy != null) {
-                foldDetectionStrategy = strategy
-                scope = CoroutineScope(Job() + Dispatchers.IO)
-                logcatJob = scope.launch { announceFoldAction() }
-                startForeground(
-                    notificationId,
-                    ScrunchApplication.instance.notificationManager.generateNotification(
-                        stopServiceAction
-                    )
-                )
-                START_STICKY
-            } else {
-                Log.d("Scrunch", "Could not detect model")
-                START_NOT_STICKY
+        return START_NOT_STICKY
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        startForeground(
+            notificationId,
+            ScrunchApplication.instance.notificationManager.generateNotification(
+                stopServiceAction
+            )
+        )
+        FoldDetectionStrategy.instanceForThisDevice?.create(this) { state ->
+            if (state == DEVICE_STATE_HALF_OPEN) {
+                //Currently ignoring this state.
+                return@create
             }
-        } else {
-            Log.d("Scrunch", "Service already running")
-            return START_NOT_STICKY
+
+            if (state != currentFoldState) {
+                val soundPlaybackManager = ScrunchApplication.instance.soundPlaybackManager
+                if (state == DEVICE_STATE_CLOSED) soundPlaybackManager.playFoldSound() else soundPlaybackManager.playUnfoldSound()
+                currentFoldState = state
+            }
         }
     }
 
@@ -93,12 +54,14 @@ class FoldActionSignalingService : Service() {
     }
 
     override fun onDestroy() {
-        scope.cancel()
-        logcatJob?.cancel("Normal stop")
-        logcatJob = null
+        FoldDetectionStrategy.instanceForThisDevice?.destroy(this)
     }
 
     companion object {
         const val stopServiceAction = "StopFoldServiceAction"
+
+        const val DEVICE_STATE_CLOSED = 1
+        const val DEVICE_STATE_FULLY_OPEN = 3
+        const val DEVICE_STATE_HALF_OPEN = 2
     }
 }

--- a/app/src/main/java/com/denytheflowerpot/scrunch/util/PermissionUtils.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/util/PermissionUtils.kt
@@ -1,0 +1,13 @@
+package com.denytheflowerpot.scrunch.util
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+
+object PermissionUtils {
+    fun needsToGrantReadLogs(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) return false
+
+        return context.checkCallingOrSelfPermission(android.Manifest.permission.READ_LOGS) != PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/app/src/main/java/com/denytheflowerpot/scrunch/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/denytheflowerpot/scrunch/viewmodels/MainViewModel.kt
@@ -1,8 +1,6 @@
 package com.denytheflowerpot.scrunch.viewmodels
 
-import android.Manifest
 import android.app.Application
-import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.AndroidViewModel
@@ -11,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import com.denytheflowerpot.scrunch.ScrunchApplication
 import com.denytheflowerpot.scrunch.managers.SettingsManager
 import com.denytheflowerpot.scrunch.managers.SoundPlaybackManager
+import com.denytheflowerpot.scrunch.util.PermissionUtils
 
 class MainViewModel(app: Application): AndroidViewModel(app) {
     private val foldSoundURL: MutableLiveData<Uri?> by lazy {
@@ -26,7 +25,7 @@ class MainViewModel(app: Application): AndroidViewModel(app) {
         MutableLiveData<Float>(settingsManager.volume)
     }
 
-    val showPermissionTutorial = app.checkSelfPermission(Manifest.permission.READ_LOGS) != PackageManager.PERMISSION_GRANTED
+    val showPermissionTutorial = PermissionUtils.needsToGrantReadLogs(app)
 
     val foldSoundName = MediatorLiveData<String>().apply {
         addSource(foldSoundURL) {


### PR DESCRIPTION
This PR reworks FoldDetectionStrategy and FoldActionSignalingService to use `DeviceStateManager#registerCallback()` on Android 12 and up.

Advantages:
- It's a permission-less callback. No ADB commands are needed for Scrunch to listen to fold state changes.
- It's device-agnostic (mostly). All Android-12 and later devices should implement this API.
- It doesn't rely on reading the log, which can be slow and resource-heavy.
- There are more potential states to detect, including a partially-open state.

Disadvantages:
- DeviceStateManager is a hidden API, so it isn't directly accessible normally. This PR doesn't currently use reflection and instead relies on a [modified SDK JAR](https://github.com/Reginer/aosp-android-jar).
- The partially-open state doesn't seem to be particularly reliable on the Z Flip 3 at least.

In changing the FoldDetectionStrategy to work with DeviceStateManager, I had to make some significant changes to how it and the FoldActionSignalingService work. As a result of those changes, it should be easier to potentially add other non-logcat-based strategies if needed.

To access hidden APIs, [LSPosed's Hidden API Bypass](https://github.com/LSPosed/AndroidHiddenApiBypass) library is used. This shouldn't have too much overhead, since it's a pure-Java solution. It also relies on the Java Unsafe API, which is unlikely to ever be blocked by Google.